### PR TITLE
Move tests outside Next pages

### DIFF
--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import Home from '../index';
+import Home from '../pages/index';
 
 describe('Home Page', () => {
   it('renders project name input', () => {


### PR DESCRIPTION
## Summary
- avoid treating tests as Next.js pages by moving `pages/__tests__` to top-level `__tests__`
- update import path in the test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688649685b748324b6a2deaabab0f9b8