### PR TITLE
Refactor Next.js app with animated UI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,159 +1,49 @@
-Eidos Design Copilot – README
-🚀 Overview
-Eidos Design Copilot is a visual, AI-powered platform for creating, editing, and managing design systems with zero coding.
-Features include a drag-and-drop playground (Blocks UI), ready-to-use component templates, real-time AI audits, and one-click deploy on Vercel with Supabase integration.
+# Eidos Demo
 
-✨ Features
-Visual editor/playground (Blocks UI-based, drag-and-drop)
+This project is a simplified Next.js + TypeScript starter showcasing reusable UI components built with TailwindCSS, shadcn/ui patterns and Framer Motion.
 
-Fully editable design system projects (import/export JSON)
+## Stack
 
-Component library (your exact base list, editable)
+- **Next.js** for the React framework
+- **TypeScript** for type safety
+- **TailwindCSS** for utility-first styling
+- **Framer Motion** for animations
+- **Jest** and **Testing Library** for basic unit tests
 
-Rules/knowledge base (import/export JSON, always editable)
+## Getting Started
 
-AI Copilot (feedback, audit, suggestions, with user API keys)
-
-Deployable on Vercel
-
-Persistent storage via Supabase (with fallback to local browser storage)
-
-Modern UI (DaisyUI, MagicUI, or shadcn/ui)
-
-100% English documentation & UI
-
-🛠️ Getting Started
-1. Clone the repo
-   git clone https://github.com/your-org/eidos-design-copilot.git
-   cd eidos-design-copilot
-2. Install dependencies
-   npm install
-3. Set up Supabase (optional but recommended)
-   - Go to supabase.com and create a free account.
-   - Create a new project.
-   - Copy your project URL and anon/public API key from Project Settings → API.
-   - Create the following tables in Supabase using the SQL editor:
-
-```
--- Projects table
-create table projects (
-  id uuid default uuid_generate_v4() primary key,
-  name text,
-  data jsonb,
-  created_at timestamp default now()
-);
-
--- Components table
-create table components (
-  id uuid default uuid_generate_v4() primary key,
-  project_id uuid references projects(id),
-  name text,
-  category text,
-  description text,
-  properties jsonb
-);
-
--- Rules table
-create table rules (
-  id uuid default uuid_generate_v4() primary key,
-  project_id uuid references projects(id),
-  rule text,
-  category text,
-  example text
-);
+```bash
+npm install
+npm run dev
 ```
 
-4. Create your `.env.local` file
+Visit `http://localhost:3000` to see the demo.
 
-```
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-```
+## Available Pages
 
-If you don’t want to use Supabase, the app stores data in your browser (localStorage/IndexedDB).
+- `/` – examples of all UI components with animations
+- `/login` – animated login form
+- `/dashboard` – protected page loading sample data from `/data`
+- `/about` – simple about page
 
-5. Run locally
-   npm run dev
-   Visit http://localhost:3000 to see Eidos in action.
+## Using Animations
 
-6. Deploy on Vercel
-   - Go to vercel.com, sign in with GitHub, and import your repo.
-   - Set the environment variables (NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY) in the Vercel project settings.
-   - Click **Deploy** — you’re live!
+All interactive components use Framer Motion. Example snippet:
 
-⚡ Configuration for Blocks UI & UI Libraries
-Blocks UI is used as the visual playground/canvas.
-
-DaisyUI, MagicUI, or shadcn/ui + Tailwind are used for the dashboard, panels, dialogs, forms, etc.
-
-You can customize styles freely, but DO NOT change the default component list or rules unless editing via the UI.
-
-🧩 Import/Export JSON
-Projects, components, and rules can be imported/exported as JSON at any time.
-
-All JSON structures must match the provided templates (see sample-components.json, sample-rules.json, and sample-project.json in the repo).
-
-Exports are ready for Figma plugins, Storybook, or other tools.
-
-🤖 AI Copilot Setup
-In the Settings/API Key panel, enter your own OpenAI, Groq, Mistral, or Gemini API key.
-
-API keys are never stored on our servers — only in your browser/session.
-
-If no key is set, AI features will be disabled until you add one.
-
-🧑‍🎨 How to use Eidos
-Start a new project from scratch, import, or use the Eidos Base System.
-
-Edit visually using the drag-and-drop playground.
-
-Add, edit, or remove components and rules in real time.
-
-Ask the AI Copilot for audits, feedback, or suggestions (AI always uses your loaded rules).
-
-Export your project as JSON when done (for Figma, Storybook, etc.).
-
-🏗️ Customization & Advanced
-You can extend, fork, or style the app further using DaisyUI, MagicUI, or shadcn/ui.
-
-For advanced users:
-
-Adapt the Supabase schema for multi-user or future authentication.
-
-Integrate new AI providers or design system marketplaces.
-
-📝 Contributing
-PRs and issues welcome! Please keep your changes in line with the Eidos philosophy:
-designer-first, simple, no vendor lock-in, always editable.
-
-📄 License
-MIT License.
-© 2024 Eidos Design Copilot, your-org.
-
-📦 Sample JSON Files
-See /samples/ for:
-
-components-base.json
-
-rules-base.json
-
-project-example.json
-
-📂 Data Directory
-The `/data/` folder stores the default design data used by the app:
-
-```
-data/baseComponents.json   - Base list of available components
-data/knowledgeBase.json    - Design rules and guidelines
-data/exportedProject.json  - Example project exported from Eidos
+```tsx
+<motion.button whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+  Hover me
+</motion.button>
 ```
 
-These files are loaded by the application at start up. The `/samples/` folder, on the other hand, contains minimal JSON templates that you can copy when creating new projects.
+## Testing
 
-🙌 Questions?
-Open an issue or contact Vlad & the team!
+Run unit tests with:
 
+```bash
+npm test
+```
 
-## Quick Start
+## Data
 
-Run `npm install` then `npm run dev` to launch the app locally at http://localhost:3000.
+The `data/` directory contains JSON files with base components used in the examples. These files must remain untouched.

--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -1,7 +1,0 @@
-export default function Canvas() {
-  return (
-    <div className="flex-1 bg-base-100 flex items-center justify-center">
-      <div className="text-gray-400">Empty state</div>
-    </div>
-  );
-}

--- a/components/RightPanel.tsx
+++ b/components/RightPanel.tsx
@@ -1,8 +1,0 @@
-export default function RightPanel() {
-  return (
-    <div className="fixed right-0 top-0 h-full w-80 bg-base-200 shadow-lg p-4 hidden md:block">
-      <h2 className="font-bold mb-2">Properties</h2>
-      <p className="text-sm text-gray-500">Select a component to edit properties.</p>
-    </div>
-  );
-}

--- a/components/__tests__/Button.test.tsx
+++ b/components/__tests__/Button.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { Button } from '../ui/Button';
+
+describe('Button', () => {
+  it('renders with provided text', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText('Click me')).toBeInTheDocument();
+  });
+});

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -1,0 +1,20 @@
+import { Header } from '../ui/Header';
+import { Sidebar } from '../ui/Sidebar';
+
+export interface LayoutProps {
+  children: React.ReactNode;
+  showSidebar?: boolean;
+}
+
+export const Layout = ({ children, showSidebar }: LayoutProps) => (
+  <div className="min-h-screen flex flex-col bg-gray-50 text-gray-900">
+    <Header />
+    <div className="flex flex-1">
+      {showSidebar && <Sidebar />}
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+    <footer className="p-4 text-center text-sm text-gray-500 border-t">
+      © 2024 Eidos
+    </footer>
+  </div>
+);

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -1,0 +1,23 @@
+import { cn } from '../../lib/utils';
+
+export interface AvatarProps {
+  src: string;
+  alt: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export const Avatar = ({ src, alt, size = 'md', className }: AvatarProps) => {
+  const sizes = {
+    sm: 'w-8 h-8',
+    md: 'w-12 h-12',
+    lg: 'w-16 h-16',
+  }[size];
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={cn('rounded-full object-cover', sizes, className)}
+    />
+  );
+};

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,16 @@
+import { cn } from '../../lib/utils';
+
+export interface BadgeProps {
+  variant?: 'default' | 'success' | 'warning';
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Badge = ({ variant = 'default', children, className }: BadgeProps) => {
+  const styles = {
+    default: 'bg-gray-200 text-gray-700',
+    success: 'bg-green-500 text-white',
+    warning: 'bg-yellow-400 text-black',
+  }[variant];
+  return <span className={cn('px-2 py-1 rounded text-xs', styles, className)}>{children}</span>;
+};

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { VariantProps, cva } from 'class-variance-authority';
+import { motion, HTMLMotionProps } from 'framer-motion';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-500 text-white hover:bg-blue-600',
+        secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200',
+      },
+      size: {
+        sm: 'px-3 py-1 text-sm',
+        md: 'px-4 py-2',
+        lg: 'px-6 py-3 text-lg',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+    },
+  }
+);
+
+export type ButtonProps = HTMLMotionProps<'button'> &
+  React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants>;
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <motion.button
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        ref={ref}
+        className={cn(buttonVariants({ variant, size }), className)}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { motion } from 'framer-motion';
+import { cn } from '../../lib/utils';
+
+export interface CardProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const Card = ({ className, children }: CardProps) => (
+  <motion.div
+    initial={{ opacity: 0, y: 10 }}
+    animate={{ opacity: 1, y: 0 }}
+    className={cn('rounded-lg bg-white shadow p-4', className)}
+  >
+    {children}
+  </motion.div>
+);

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { Button } from './Button';
+
+export const Header = () => (
+  <motion.header
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    className="flex items-center justify-between h-16 px-6 bg-white border-b"
+  >
+    <Link href="/" legacyBehavior>
+      <a className="font-bold">Eidos</a>
+    </Link>
+    <nav className="space-x-4">
+      <Link href="/login" legacyBehavior>
+        <a className="text-sm text-gray-600 hover:underline">Login</a>
+      </Link>
+    </nav>
+  </motion.header>
+);

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = 'Input';

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { cn } from '../../lib/utils';
+import { Button } from './Button';
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+export const Modal: React.FC<ModalProps> = ({ open, onClose, title, children }) => (
+  <AnimatePresence>
+    {open && (
+      <motion.div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <motion.div
+          initial={{ scale: 0.9, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.9, opacity: 0 }}
+          className="bg-white rounded-lg shadow-lg p-6 w-full max-w-md"
+        >
+          {title && <h2 className="text-lg font-semibold mb-4">{title}</h2>}
+          <div className="mb-4">{children}</div>
+          <div className="text-right">
+            <Button onClick={onClose}>Close</Button>
+          </div>
+        </motion.div>
+      </motion.div>
+    )}
+  </AnimatePresence>
+);

--- a/components/ui/Panel.tsx
+++ b/components/ui/Panel.tsx
@@ -1,0 +1,14 @@
+import { cn } from '../../lib/utils';
+
+export interface PanelProps {
+  title: string;
+  children?: React.ReactNode;
+  className?: string;
+}
+
+export const Panel = ({ title, children, className }: PanelProps) => (
+  <div className={cn('bg-gray-50 p-4 rounded-md shadow', className)}>
+    <h2 className="font-semibold mb-2">{title}</h2>
+    {children}
+  </div>
+);

--- a/components/ui/Sidebar.tsx
+++ b/components/ui/Sidebar.tsx
@@ -1,0 +1,39 @@
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { cn } from '../../lib/utils';
+
+export interface SidebarProps {
+  className?: string;
+}
+
+export const Sidebar: React.FC<SidebarProps> = ({ className }) => {
+  const router = useRouter();
+  const links = [
+    { href: '/', label: 'Home' },
+    { href: '/dashboard', label: 'Dashboard' },
+    { href: '/about', label: 'About' },
+  ];
+  return (
+    <motion.aside
+      initial={{ x: -240 }}
+      animate={{ x: 0 }}
+      className={cn('w-48 bg-gray-100 h-screen p-4 space-y-2', className)}
+    >
+      {links.map((l) => (
+        <Link key={l.href} href={l.href} legacyBehavior>
+          <a
+            className={cn(
+              'block px-3 py-2 rounded-md',
+              router.pathname === l.href
+                ? 'bg-blue-500 text-white'
+                : 'hover:bg-gray-200'
+            )}
+          >
+            {l.label}
+          </a>
+        </Link>
+      ))}
+    </motion.aside>
+  );
+};

--- a/components/ui/SkeletonLoader.tsx
+++ b/components/ui/SkeletonLoader.tsx
@@ -1,0 +1,9 @@
+import { cn } from '../../lib/utils';
+
+export interface SkeletonProps {
+  className?: string;
+}
+
+export const SkeletonLoader = ({ className }: SkeletonProps) => (
+  <div className={cn('animate-pulse rounded bg-gray-200', className)} />
+);

--- a/components/ui/Tooltip.tsx
+++ b/components/ui/Tooltip.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export interface TooltipProps {
+  text: string;
+  children: React.ReactNode;
+}
+
+export const Tooltip = ({ text, children }: TooltipProps) => {
+  const [show, setShow] = React.useState(false);
+  return (
+    <div
+      className="relative inline-block"
+      onMouseEnter={() => setShow(true)}
+      onMouseLeave={() => setShow(false)}
+    >
+      {children}
+      <AnimatePresence>
+        {show && (
+          <motion.div
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 4 }}
+            className="absolute left-1/2 top-full mt-1 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1"
+          >
+            {text}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,6 @@ module.exports = {
     ...tsJestPreset.transform,
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  testMatch: ['**/__tests__/**/*.(ts|tsx)'],
+  testMatch: ['**/__tests__/**/*.(ts|tsx)', '<rootDir>/tests/**/*.(ts|tsx)'],
 };
 

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface AuthContextProps {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+const AuthContext = React.createContext<AuthContextProps | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isAuthenticated, setAuth] = React.useState(false);
+  const login = () => setAuth(true);
+  const logout = () => setAuth(false);
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = React.useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.0",
         "daisyui": "^5.0.47",
+        "framer-motion": "^11.0.1",
         "next": "^15.4.4",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "tailwind-merge": "^2.2.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.11",
@@ -3736,6 +3740,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3755,6 +3771,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -4891,6 +4916,33 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -8775,6 +8827,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9714,6 +9781,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,14 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
     "daisyui": "^5.0.47",
+    "framer-motion": "^11.0.1",
     "next": "^15.4.4",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "tailwind-merge": "^2.2.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/pages/__tests__/index.test.tsx
+++ b/pages/__tests__/index.test.tsx
@@ -1,9 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import Home from '../index';
-
-describe('Home Page', () => {
-  it('renders project name input', () => {
-    render(<Home />);
-    expect(screen.getByPlaceholderText('Project Name')).toBeInTheDocument();
-  });
-});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,19 @@
 import type { AppProps } from 'next/app';
+import { useRouter } from 'next/router';
+import { AnimatePresence } from 'framer-motion';
 import '../styles/globals.css';
+import { Layout } from '../components/layout/Layout';
+import { AuthProvider } from '../lib/auth';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  const router = useRouter();
+  return (
+    <AuthProvider>
+      <AnimatePresence mode="wait" initial={false}>
+        <Layout showSidebar={router.pathname.startsWith('/dashboard')}>
+          <Component {...pageProps} key={router.asPath} />
+        </Layout>
+      </AnimatePresence>
+    </AuthProvider>
+  );
 }

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,13 @@
+import { motion } from 'framer-motion';
+
+export default function About() {
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-4">
+      <h1 className="text-2xl font-bold">About Eidos</h1>
+      <p>
+        Eidos is a small demo showcasing reusable React components built with TailwindCSS and Framer Motion.
+        It loads sample data from the <code>/data</code> folder and demonstrates page transitions and micro interactions.
+      </p>
+    </motion.div>
+  );
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../lib/auth';
+import { useRouter } from 'next/router';
+import componentsData from '../data/baseComponents.json';
+import { Card } from '../components/ui/Card';
+import { SkeletonLoader } from '../components/ui/SkeletonLoader';
+import { Button } from '../components/ui/Button';
+
+export default function Dashboard() {
+  const { isAuthenticated, logout } = useAuth();
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setLoading(false), 800);
+    return () => clearTimeout(t);
+  }, []);
+
+  if (!isAuthenticated) {
+    return (
+      <div className="space-y-4">
+        <p>You must be logged in to view the dashboard.</p>
+        <Button onClick={() => router.push('/login')}>Go to Login</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <Button variant="secondary" onClick={logout}>Logout</Button>
+      </div>
+      {loading ? (
+        <SkeletonLoader className="h-40" />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {componentsData.slice(0,6).map((c) => (
+            <Card key={c.name}>
+              <h3 className="font-semibold">{c.name}</h3>
+              <p className="text-sm text-gray-600">{c.description}</p>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,42 +1,44 @@
-import RightPanel from '../components/RightPanel';
-import Canvas from '../components/Canvas';
+import { useState } from 'react';
+import { Button } from '../components/ui/Button';
+import { Card } from '../components/ui/Card';
+import { Input } from '../components/ui/Input';
+import { Modal } from '../components/ui/Modal';
+import { Badge } from '../components/ui/Badge';
+import { Avatar } from '../components/ui/Avatar';
+import { Tooltip } from '../components/ui/Tooltip';
+import { SkeletonLoader } from '../components/ui/SkeletonLoader';
+import componentsData from '../data/baseComponents.json';
 
 export default function Home() {
+  const [open, setOpen] = useState(false);
   return (
-    <div className="flex h-screen">
-      {/* Left Sidebar */}
-      <aside className="w-20 bg-base-200 p-4 flex flex-col justify-between">
-        <nav className="space-y-4">
-          <button className="btn btn-ghost btn-lg" aria-label="Home">🏠</button>
-          <button className="btn btn-ghost btn-lg" aria-label="Library">📚</button>
-          <button className="btn btn-ghost btn-lg" aria-label="Measure">📏</button>
-          <button className="btn btn-ghost btn-lg" aria-label="Settings">⚙️</button>
-          <button className="btn btn-ghost btn-lg" aria-label="Projects">🗂️</button>
-        </nav>
-        <div className="mt-auto">
-          <button className="btn btn-ghost" aria-label="API Key">🔑</button>
-        </div>
-      </aside>
-
-      {/* Main Area */}
-      <div className="flex-1 flex flex-col">
-        {/* Top Bar */}
-        <header className="navbar bg-base-100 border-b border-base-300 justify-between">
-          <input
-            type="text"
-            className="input input-bordered"
-            placeholder="Project Name"
-          />
-          <div className="space-x-2">
-            <button className="btn" aria-label="AI Copilot">🤖</button>
-            <button className="btn">💾 Export</button>
-          </div>
-        </header>
-
-        {/* Canvas Area */}
-        <Canvas />
-        <RightPanel />
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">UI Components Demo</h1>
+      <div className="flex space-x-4">
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <Button variant="secondary">Secondary</Button>
       </div>
+      <Card className="max-w-md">
+        <p className="mb-2">This is a card component with data from /data:</p>
+        <ul className="list-disc list-inside text-sm">
+          {componentsData.slice(0,3).map((c) => (
+            <li key={c.name}>{c.name}</li>
+          ))}
+        </ul>
+      </Card>
+      <div className="flex items-center space-x-2">
+        <Input placeholder="Type here" className="w-64" />
+        <Badge>New</Badge>
+        <Tooltip text="User Avatar">
+          <Avatar src="https://placekitten.com/100" alt="user" size="sm" />
+        </Tooltip>
+      </div>
+      <div className="w-32 h-8">
+        <SkeletonLoader className="h-full" />
+      </div>
+      <Modal open={open} onClose={() => setOpen(false)} title="Example Modal">
+        <p>This modal uses Framer Motion for animations.</p>
+      </Modal>
     </div>
   );
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,30 @@
+import { useAuth } from '../lib/auth';
+import { useRouter } from 'next/router';
+import { Button } from '../components/ui/Button';
+import { Input } from '../components/ui/Input';
+import { useState } from 'react';
+
+export default function Login() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = () => {
+    setLoading(true);
+    setTimeout(() => {
+      login();
+      router.push('/dashboard');
+    }, 800);
+  };
+
+  return (
+    <div className="max-w-sm mx-auto space-y-4">
+      <h1 className="text-xl font-bold">Login</h1>
+      <Input placeholder="Username" />
+      <Input type="password" placeholder="Password" />
+      <Button onClick={handleLogin} disabled={loading} className="w-full">
+        {loading ? 'Loading...' : 'Sign in'}
+      </Button>
+    </div>
+  );
+}

--- a/samples/components-base.json
+++ b/samples/components-base.json
@@ -1,6 +1,0 @@
-{
-  "components": [
-    {"name": "Button", "category": "Base", "properties": {"text": "Button"}},
-    {"name": "Card", "category": "Base", "properties": {"title": "Card"}}
-  ]
-}

--- a/samples/project-example.json
+++ b/samples/project-example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Example Project",
-  "components": [],
-  "rules": []
-}

--- a/samples/rules-base.json
+++ b/samples/rules-base.json
@@ -1,6 +1,0 @@
-{
-  "rules": [
-    {"rule": "Use accessible colors", "category": "Accessibility"},
-    {"rule": "Consistent spacing", "category": "Layout"}
-  ]
-}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
 html, body {
   height: 100%;
+  font-family: theme('fontFamily.sans');
+  background-color: #F3F4F6;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,16 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: '#3B82F6',
+        grayBg: '#F3F4F6',
+        dark: '#111827',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [require('daisyui')],
 };

--- a/tests/pages/index.test.tsx
+++ b/tests/pages/index.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../../pages/index';
+
+describe('Home Page', () => {
+  it('renders heading', () => {
+    render(<Home />);
+    expect(screen.getByText('UI Components Demo')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- clean up sample folders and old components
- add shadcn-style UI components using Tailwind and Framer Motion
- implement global layout with header and sidebar
- create pages (home, login, dashboard, about)
- integrate data from `/data` and add animations
- add simple Button test and move tests out of `pages`
- update Tailwind config and global styles
- refresh README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68865309f4d08324be5b2790040a9b47